### PR TITLE
Modularize project structure

### DIFF
--- a/commiter/config.py
+++ b/commiter/config.py
@@ -1,0 +1,8 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+BASE_PATH = os.getenv("PROJECT_BASE_PATH")
+if not BASE_PATH or not os.path.isdir(BASE_PATH):
+    raise ValueError("PROJECT_BASE_PATH ist nicht gesetzt oder ungültig.")

--- a/commiter/git_utils.py
+++ b/commiter/git_utils.py
@@ -1,0 +1,48 @@
+import os
+import subprocess
+
+
+def is_git_repo(path: str) -> bool:
+    return os.path.isdir(os.path.join(path, ".git"))
+
+
+def has_github_remote(path: str) -> bool:
+    try:
+        remotes = subprocess.check_output(["git", "-C", path, "remote", "-v"]).decode()
+        return any("github.com" in line for line in remotes.splitlines())
+    except subprocess.CalledProcessError:
+        return False
+
+
+def has_changes(path: str) -> bool:
+    try:
+        status = subprocess.check_output(["git", "-C", path, "status", "--porcelain"]).decode()
+        return bool(status.strip())
+    except subprocess.CalledProcessError:
+        return False
+
+
+def get_diff(path: str) -> str:
+    """Return the diff of staged changes for the given git repository."""
+    try:
+        return subprocess.check_output([
+            "git",
+            "-C",
+            path,
+            "diff",
+            "--staged",
+        ]).decode()
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def commit_changes(path: str, message: str) -> None:
+    subprocess.run(["git", "-C", path, "add", "."], check=True)
+    subprocess.run(["git", "-C", path, "commit", "-m", message], check=True)
+
+
+def push_changes(path: str) -> None:
+    try:
+        subprocess.run(["git", "-C", path, "push"], check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Failed to push changes in {path}: {e}")

--- a/commiter/openai_utils.py
+++ b/commiter/openai_utils.py
@@ -1,0 +1,19 @@
+from openai import OpenAI
+
+client = OpenAI()
+
+
+def generate_commit_message(diff: str) -> str:
+    prompt = (
+        "Write a concise and clear git commit message summarizing the following diff:\n"
+        f"{diff}\n"
+    )
+    response = client.chat.completions.create(
+        model="gpt-4",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant who writes concise git commit messages."},
+            {"role": "user", "content": prompt}
+        ],
+        max_tokens=100
+    )
+    return response.choices[0].message.content.strip()

--- a/main.py
+++ b/main.py
@@ -1,86 +1,33 @@
 import os
 import subprocess
-from dotenv import load_dotenv
-from openai import OpenAI
 
-# .env laden
-load_dotenv()
+from commiter.config import BASE_PATH
+from commiter.git_utils import (
+    is_git_repo,
+    has_github_remote,
+    has_changes,
+    get_diff,
+    commit_changes,
+    push_changes,
+)
+from commiter.openai_utils import generate_commit_message
 
-# OpenAI-Client initialisieren
-client = OpenAI()
 
-# Projektverzeichnis aus .env
-base_path = os.getenv("PROJECT_BASE_PATH")
-
-if not base_path or not os.path.isdir(base_path):
-    raise ValueError("PROJECT_BASE_PATH ist nicht gesetzt oder ungültig.")
-
-def is_git_repo(path):
-    return os.path.isdir(os.path.join(path, ".git"))
-
-def has_github_remote(path):
-    try:
-        remotes = subprocess.check_output(["git", "-C", path, "remote", "-v"]).decode()
-        return any("github.com" in line for line in remotes.splitlines())
-    except subprocess.CalledProcessError:
-        return False
-
-def has_changes(path):
-    try:
-        status = subprocess.check_output(["git", "-C", path, "status", "--porcelain"]).decode()
-        return bool(status.strip())
-    except subprocess.CalledProcessError:
-        return False
-
-def get_diff(path):
-    """Return the diff of staged changes for the given git repository."""
-    try:
-        return subprocess.check_output([
-            "git",
-            "-C",
-            path,
-            "diff",
-            "--staged",
-        ]).decode()
-    except subprocess.CalledProcessError:
-        return ""
-
-def generate_commit_message(diff):
-    prompt = f"Write a concise and clear git commit message summarizing the following diff:\n{diff}\n"
-    response = client.chat.completions.create(
-        model="gpt-4",
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant who writes concise git commit messages."},
-            {"role": "user", "content": prompt}
-        ],
-        max_tokens=100
-    )
-    return response.choices[0].message.content.strip()
-
-def commit_changes(path, message):
-    subprocess.run(["git", "-C", path, "add", "."], check=True)
-    subprocess.run(["git", "-C", path, "commit", "-m", message], check=True)
-
-def push_changes(path):
-    try:
-        subprocess.run(["git", "-C", path, "push"], check=True)
-    except subprocess.CalledProcessError as e:
-        print(f"❌ Failed to push changes in {path}: {e}")
-
-def scan_and_commit(base_path):
+def scan_and_commit(base_path: str = BASE_PATH) -> None:
     for root, dirs, _ in os.walk(base_path):
         if is_git_repo(root) and has_github_remote(root):
-            print(f"📁 GitHub-Repo gefunden: {root}")
+            print(f"\U0001F4C1 GitHub-Repo gefunden: {root}")
             if has_changes(root):
-                print(f"🔄 Änderungen gefunden in {root}")
+                print(f"\U0001F501 \u00c4nderungen gefunden in {root}")
                 subprocess.run(["git", "-C", root, "add", "-A"], check=True)
                 diff = get_diff(root)
                 if diff:
                     message = generate_commit_message(diff)
-                    print(f"📝 Commit-Message: {message}")
+                    print(f"\U0001F4DD Commit-Message: {message}")
                     commit_changes(root, message)
                     push_changes(root)
             dirs.clear()  # Unterordner nicht rekursiv prüfen
 
+
 if __name__ == "__main__":
-    scan_and_commit(base_path)
+    scan_and_commit()


### PR DESCRIPTION
## Summary
- move git and OpenAI helpers into a `commiter` package
- load project base path from `commiter.config`
- update `main.py` to use the new modules
- clean up pycache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848210adfa08324acbf03a3fc117d25