### PR TITLE
Add confirmation prompt for commit message

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,8 +24,12 @@ def scan_and_commit(base_path: str = BASE_PATH) -> None:
                 if diff:
                     message = generate_commit_message(diff)
                     print(f"\U0001F4DD Commit-Message: {message}")
-                    commit_changes(root, message)
-                    push_changes(root)
+                    confirm = input("Commit message verwenden? (y/[n]): ").strip().lower()
+                    if confirm == "y":
+                        commit_changes(root, message)
+                        push_changes(root)
+                    else:
+                        print("Commit abgebrochen.")
             dirs.clear()  # Unterordner nicht rekursiv prüfen
 
 


### PR DESCRIPTION
## Summary
- ask for a `y` confirmation before committing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684825cb26308324aa5d0c550c160e19