### PR TITLE
Refine git commit logic

### DIFF
--- a/commiter/git_utils.py
+++ b/commiter/git_utils.py
@@ -37,8 +37,10 @@ def get_diff(path: str) -> str:
 
 
 def commit_changes(path: str, message: str) -> None:
-    subprocess.run(["git", "-C", path, "add", "."], check=True)
-    subprocess.run(["git", "-C", path, "commit", "-m", message], check=True)
+    try:
+        subprocess.run(["git", "-C", path, "commit", "-m", message], check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"❌ Failed to commit changes in {path}: {e}")
 
 
 def push_changes(path: str) -> None:


### PR DESCRIPTION
## Summary
- avoid re-staging files in `commit_changes`
- catch commit errors so they don't abort execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482b7b44708324b8793977562bac50